### PR TITLE
Fix remote->local sync errors (git:// prefix and suffix on files)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -431,7 +431,7 @@ export function activate(context: ExtensionContext): void {
     });
 
     workspace.onDidOpenTextDocument((doc: TextDocument): void => {
-        if (config.onFileLoadIndividual) {
+        if (config.onFileLoadIndividual && doc.uri.scheme == 'file') {
             syncFile(config, config.translatePath(doc.fileName), true);
         }
     });


### PR DESCRIPTION
`window.onDidOpenTextDocument` fires few events for every file opened with different uri scheme, so sometimes plugin receives file with `.git` ending. 