### PR TITLE
Show vs code error for falsy value of remote.

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -146,8 +146,8 @@ export class Config {
     }
 
     translatePath(path: string): string {
-        
-        if(path == null) return null;
+
+        if(!path) return null;
         
         if(path[0] == '/') return path;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ const syncSite = async function (site: Site, config: Config, { down, dry }: { do
     }
 
     if (site.remotePath === null) {
-        vscWindow.showErrorMessage('Sync-Rsync: you must configure a remote');
+        vscWindow.showErrorMessage('Sync-Rsync: you must configure a remote properly');
         return false;
     }
 
@@ -257,7 +257,7 @@ const syncFile = async function (config: Config, file: string, down: boolean): P
         }
 
         if (site.remotePath === null) {
-            vscWindow.showErrorMessage('Sync-Rsync: you must configure a remote');
+            vscWindow.showErrorMessage('Sync-Rsync: you must configure a remote properly');
             continue;
         }
 


### PR DESCRIPTION
An error message is displayed on VS code if the remote path is [Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) which resolves https://github.com/thisboyiscrazy/vscode-rsync/issues/97 https://github.com/thisboyiscrazy/vscode-rsync/issues/126.